### PR TITLE
File-level RecordInfo name

### DIFF
--- a/src/tests/dspf.test.ts
+++ b/src/tests/dspf.test.ts
@@ -12,7 +12,10 @@ describe('DisplayFile tests', () => {
     `     A                                  1  3'Opt'                               `,
     `     A                                      COLOR(BLU)                          `,
     `     A                                  1  8'Name'                              `,
-    `     A                                      COLOR(BLU)                          `
+    `     A                                      COLOR(BLU)                          `,
+    `     A          R GLOBAL                                                        `,     
+    `     A                                      SLNO(04)                            `,
+    `     A                                  1  3'---'                               `,
   ];
 
   it('getRangeForFormat', () => {
@@ -26,12 +29,17 @@ describe('DisplayFile tests', () => {
     range = dds.getRangeForFormat(`FMT1`);
     expect(range?.start).toBe(3);
     expect(range?.end).toBe(9);
-    expect(true).toBe(true);
 
     range = dds.getRangeForFormat(`HEAD`);
     expect(range?.start).toBe(1);
     expect(range?.end).toBe(3);
-    expect(true).toBe(true);
+  });
+
+  it('No duplicate RecordInfo', () => {
+    let dds = new DisplayFile();
+    dds.parse(dspf1);
+    let names = dds.formats.map(rcd => rcd.name);
+    expect(new Set(names).size).toBe(names.length);
   });
 
 });

--- a/src/ui/dspf.ts
+++ b/src/ui/dspf.ts
@@ -2,7 +2,7 @@
 export interface DdsLineRange { start: number, endHeader?: number, end: number };
 export interface DdsUpdate { newLines: string[], range?: DdsLineRange };
 
-const GLOBAL_RECORD_NAME = `GLOBAL`;
+const GLOBAL_RECORD_NAME = `_GLOBAL`;
 
 export class DisplayFile {
   public formats: RecordInfo[] = [];


### PR DESCRIPTION
Change RecordInfo name for file-level entries from "GLOBAL" to "_GLOBAL" which is a invalid record format name that should not be used.

Otherwise one could create a record format named "GLOBAL" and the parser would create two RecordInfo entries