### PR TITLE
Adding line number, linetext and record reference to FieldInfo for Field Level Impact Analysis in understand

### DIFF
--- a/src/dspf.js
+++ b/src/dspf.js
@@ -175,7 +175,7 @@ class DisplayFile {
               this.currentField.displayType = `const`;
               this.currentField.lineIndex = index;
               this.currentField.lineText = line;
-                if (line[28] === 'R') {
+              if (line[28] === 'R') {
                 this.currentField.isRecordReference = true;
               }
             

--- a/test/file/recordref.js
+++ b/test/file/recordref.js
@@ -1,0 +1,9 @@
+exports.lines = [
+`     A                                      REF(PF1)`,
+`     A          R TESTFMT`,
+`     A            FIELD1    R   10A  O  5 10`,
+`     A            NORMALFLD     15A  B  6 10`,
+`     A            FIELD2    R   20A  O  7 10`,
+`     A            FIELD3    R    5Y 0H`,
+`     A                                  8 10'Text Field'`,
+];

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,6 +5,7 @@ const depts = require("./file/depts");
 const replloadfm = require("./file/replloadfm");
 const issue1149 = require(`./file/issue1149`);
 const issue1382 = require(`./file/issue1382`);
+const recordref = require(`./file/recordref`);
 
 exports.simple = () => {
   const file = new DisplayFile();
@@ -173,4 +174,30 @@ exports.issue1382 = () => {
   const textField2 = screenFormat.fields[1];
   assert.strictEqual(textField2.name, `TEXT2`);
   assert.strictEqual(textField2.value, `This text containt dashes -Y/N-`);
+}
+
+exports.fieldMetadata = () => {
+  const file = new DisplayFile();
+  file.parse(recordref.lines);
+
+  assert.strictEqual(file.formats.length, 2);
+
+  const testFormat = file.formats[1];
+  assert.strictEqual(testFormat.name, `TESTFMT`);
+  assert.strictEqual(testFormat.fields.length, 5);
+
+  // Test field with 'R' at position 28 (isRecordReference = true)
+  const field1 = testFormat.fields[0];
+  assert.strictEqual(field1.name, `FIELD1`);
+  assert.strictEqual(field1.lineIndex, 2);
+  assert.strictEqual(field1.lineText, '     A            FIELD1    R   10A  O  5 10                                    ');
+  assert.strictEqual(field1.isRecordReference, true);
+
+  // Test normal field without 'R' at position 28 (isRecordReference = false)
+  const normalField = testFormat.fields[1];
+  assert.strictEqual(normalField.name, `NORMALFLD`);
+  assert.strictEqual(normalField.lineIndex, 3);
+  assert.strictEqual(normalField.lineText, '     A            NORMALFLD     15A  B  6 10                                    ');
+  assert.strictEqual(normalField.isRecordReference, false);
+
 }


### PR DESCRIPTION
For Field Level Impact analysis in Understand server, following data is required from dds parser FieldInfo interface

1. Line Number - Referenced field line number in DSPF file
2. Line Text - Referenced field line number in DSPF file
3. Record Reference (R keyword) - Record Reference in DSPF file.

@worksofliam