### PR TITLE
removed type!=="" to get all the fields accurately

### DIFF
--- a/src/tests/dspf.test.ts
+++ b/src/tests/dspf.test.ts
@@ -137,4 +137,50 @@ describe('DisplayFile tests', () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
+  it("should parse field with type and attach keywords", () => {
+    const lines = [
+      "     A            FIELD1        10A",
+      "     A                                      TEXT('Customer Name')",
+      "     A                                      COLHDG('Cust' 'Name')"
+    ];
+
+    const file = new DisplayFile();
+    file.parse(lines);
+
+    const record = file.formats[0];
+    const field = record.fields[0];
+
+    expect(record.fields.length).toBe(1);
+    expect(field.name).toBe("FIELD1");
+    expect(field.type).toBe("A");
+    expect(field.length).toBe(10);
+    expect(field.keywords.length).toBe(2);
+    expect(field.keywords[0].name).toBe("TEXT");
+    expect(field.keywords[0].value).toBe("'Customer Name'");
+    expect(field.keywords[1].name).toBe("COLHDG");
+    expect(field.keywords[1].value).toBe("'Cust' 'Name'");
+  });
+
+  it("should parse field without type (REFFLD) and attach keywords", () => {
+    const lines = [
+      "     A            FIELD2",
+      "     A                                      REFFLD(ADRNO)",
+      "     A                                      TEXT('Address Number')"
+    ];
+
+    const file = new DisplayFile();
+    file.parse(lines);
+
+    const record = file.formats[0];
+    const field = record.fields[0];
+
+    expect(record.fields.length).toBe(1);
+    expect(field.name).toBe("FIELD2");
+    expect(field.type).toBe("");
+    expect(field.keywords.length).toBe(2);
+    expect(field.keywords[0].name).toBe("REFFLD");
+    expect(field.keywords[0].value).toBe("ADRNO");
+    expect(field.keywords[1].name).toBe("TEXT");
+    expect(field.keywords[1].value).toBe("'Address Number'");
+  });
 });

--- a/src/ui/dspf.ts
+++ b/src/ui/dspf.ts
@@ -95,7 +95,7 @@ export class DisplayFile {
               x: totalX,
               y: 0
             };
-          } else if (name !== undefined && type !== "") {
+          } else if (name!=="" && name !== undefined) {
             // Some fields have no positions
             if (this.currentField) {
               this.currentField.handleKeywords();

--- a/src/ui/dspf.ts
+++ b/src/ui/dspf.ts
@@ -95,7 +95,7 @@ export class DisplayFile {
               x: totalX,
               y: 0
             };
-          } else if (name!=="" && name !== undefined) {
+          } else if (name!=="" && name !== undefined) { // start a new field if a field name exists
             // Some fields have no positions
             if (this.currentField) {
               this.currentField.handleKeywords();


### PR DESCRIPTION
Hi @worksofliam, Removed the type !=="" condition to ensure all fields are parsed accurately for PF and LF files.
references: https://github.com/codefori/vscode-ibmi-renderer/issues/15 , https://github.ibm.com/bob-for-ibm-i/vscode-ibmi-bob/issues/282
Additionally, added two test cases to verify that fields are parsed correctly after this change.
@venky225 @SanjulaGanepola